### PR TITLE
Make Handlebars::Context.current thread safe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 rvm:
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
+  - 2.4.1
+  - 2.3.4
+  - 2.2.7
 before_install:
   - gem update bundler

--- a/handlebars.gemspec
+++ b/handlebars.gemspec
@@ -12,8 +12,10 @@ Gem::Specification.new do |s|
 
   s.files         = `git ls-files lib README.mdown`.split("\n")
 
+  s.required_ruby_version = '>= 2.0.0'
+
   s.add_dependency "therubyracer", "~> 0.12.1"
-  s.add_dependency "handlebars-source", "~> 4.0.5"
+  s.add_dependency "handlebars-source", "~> 4.0.8"
   s.add_development_dependency "rake"
-  s.add_development_dependency "rspec", "~> 2.0"
+  s.add_development_dependency "rspec", "~> 3.6.0"
 end

--- a/lib/handlebars/context.rb
+++ b/lib/handlebars/context.rb
@@ -3,6 +3,14 @@ require 'v8'
 
 module Handlebars
   class Context
+    def self.current
+      Thread.current.thread_variable_get(:current)
+    end
+
+    def self.current=(context)
+      Thread.current.thread_variable_set(:current, context)
+    end
+
     def initialize
       @js = V8::Context.new
       @js['global'] = {} # there may be a more appropriate object to be used here @MHW
@@ -53,10 +61,6 @@ module Handlebars
 
     def [](key)
       data[key]
-    end
-
-    class << self
-      attr_accessor :current
     end
 
     private

--- a/lib/handlebars/template.rb
+++ b/lib/handlebars/template.rb
@@ -3,7 +3,7 @@ module Handlebars
     def initialize(context, fn)
       @context, @fn = context, fn
     end
-    
+
     def call(*args)
       current = Handlebars::Context.current
       Handlebars::Context.current = @context

--- a/spec/handlebars/context_spec.rb
+++ b/spec/handlebars/context_spec.rb
@@ -1,0 +1,13 @@
+require 'handlebars'
+
+RSpec.describe Handlebars::Context do
+  describe '.current=' do
+    it 'is thread safe' do
+      expect {
+        Thread.new { Handlebars::Context.current = 'thread_context' }.join
+      }.to_not change {
+        Handlebars::Context.current
+      }.from(nil)
+    end
+  end
+end

--- a/spec/handlebars_spec.rb
+++ b/spec/handlebars_spec.rb
@@ -4,22 +4,22 @@ describe(Handlebars::Context) do
   describe "a simple template" do
     let(:t) { compile("Hello {{name}}") }
     it "allows simple subsitution" do
-      t.call(:name => 'World').should eql "Hello World"
+      expect(t.call(:name => 'World')).to eql "Hello World"
     end
 
     it "allows Ruby blocks as a property" do
-      t.call(:name => lambda { |context| ; "Mate" }).should eql "Hello Mate"
+      expect(t.call(:name => lambda { |context| ; "Mate" })).to eql "Hello Mate"
     end
 
     it "can use any Ruby object as a context" do
-      t.call(double(:Object, :name => "Flipper")).should eql "Hello Flipper"
+      expect(t.call(double(:Object, :name => "Flipper"))).to eql "Hello Flipper"
     end
   end
 
   describe "allows Handlebars whitespace operator" do
     let(:t) { compile("whitespace    {{~word~}}   be replaced.") }
     it "consumes all whitespace characters before/after the tag with the whitespace operator" do
-      t.call(:word => "should").should eql "whitespaceshouldbe replaced."
+      expect(t.call(:word => "should")).to eql "whitespaceshouldbe replaced."
     end
   end
 
@@ -30,7 +30,7 @@ describe(Handlebars::Context) do
 
     it "can call helpers defined in a javascript file" do
       t = compile('{{#nthTimes 2}}yep {{/nthTimes}}hurrah!')
-      t.call.should eql 'yep yep hurrah!'
+      expect(t.call).to eql 'yep yep hurrah!'
     end
   end
 
@@ -46,12 +46,12 @@ describe(Handlebars::Context) do
 
     it "correctly passes context and implementation" do
       t = compile("it's so {{#alsowith weather}}*{{summary}}*{{/alsowith}}!")
-      t.call(:weather => {:summary => "sunny"}).should eql "it's so *sunny*!"
+      expect(t.call(:weather => {:summary => "sunny"})).to eql "it's so *sunny*!"
     end
 
     it "doesn't nee a context or arguments to the call" do
       t = compile("{{#twice}}Hurray!{{/twice}}")
-      t.call.should eql "Hurray!Hurray!"
+      expect(t.call).to eql "Hurray!Hurray!"
     end
   end
 
@@ -60,7 +60,7 @@ describe(Handlebars::Context) do
       subject.register_partial('legend', 'I am {{who}}')
     end
     it "renders partials" do
-      compile("{{> legend}}").call(:who => 'Legend!').should eql "I am Legend!"
+      expect(compile("{{> legend}}").call(:who => 'Legend!')).to eql "I am Legend!"
     end
   end
 
@@ -69,7 +69,7 @@ describe(Handlebars::Context) do
       subject.partial_missing do |name|
         "unable to find >#{name}"
       end
-      compile("I am {{>missing}}").call().should eql "I am unable to find >missing"
+      expect(compile("I am {{>missing}}").call()).to eql "I am unable to find >missing"
     end
 
     it "can be done with a function" do
@@ -78,28 +78,28 @@ describe(Handlebars::Context) do
           "unable to find my #{name} #{context.what}"
         end
       end
-      compile("I am {{>missing}}").call(:what => 'shoes').should eql "I am unable to find my missing shoes"
+      expect(compile("I am {{>missing}}").call(:what => 'shoes')).to eql "I am unable to find my missing shoes"
     end
   end
 
   describe "creating safe strings from ruby" do
     let(:t) { subject.compile("{{safe}}") }
     it "respects safe strings returned from ruby blocks" do
-      t.call(:safe => lambda { |this, *args| Handlebars::SafeString.new("<pre>totally safe</pre>") }).should eql "<pre>totally safe</pre>"
+      expect(t.call(:safe => lambda { |this, *args| Handlebars::SafeString.new("<pre>totally safe</pre>") })).to eql "<pre>totally safe</pre>"
     end
   end
 
   describe "context specific data" do
     before { subject['foo'] = 'bar' }
     it 'can be get and set' do
-      subject['foo'].should eql 'bar'
+      expect(subject['foo']).to eql 'bar'
     end
   end
 
   describe "precompiling templates" do
     let(:t) { precompile("foo {{bar}}") }
     it "should compile down to javascript" do
-      t.should include 'function'
+      expect(t).to include 'function'
     end
   end
 
@@ -118,7 +118,7 @@ describe(Handlebars::Context) do
       end
     end
     it "sets the index variable correctly" do
-      t.call(:array => [{:title => "You are"}, {:title => "He is"}]).should == "<ul><li>0. You are dummy</li><li>1. He is dummy</li></ul>"
+      expect(t.call(:array => [{:title => "You are"}, {:title => "He is"}])).to eq("<ul><li>0. You are dummy</li><li>1. He is dummy</li></ul>")
     end
   end
 
@@ -131,7 +131,7 @@ describe(Handlebars::Context) do
       end
     end
     it "accepts hash attributes correctly" do
-      t.call({nav: [{url: 'url', title: 'title'}]}).should == %(<ul class="top" id="nav-bar"><li><a href="url">title</a></li></ul>)
+      expect(t.call({nav: [{url: 'url', title: 'title'}]})).to eq('<ul class="top" id="nav-bar"><li><a href="url">title</a></li></ul>')
     end
   end
 


### PR DESCRIPTION
Handlebars::Template#call was mutating global state. When called in
multiple threads you ran the risk of overwriting the current context for
other threads while the @fn.call was executing. By moving to a thread
variable we ensure that this value remains with the thread which is
setting the value.

Also in this PR are some dependency updates including requiring a modern
ruby. All three ruby versions previously tested are no longer
maintained.